### PR TITLE
Enable serialising empty string as object values

### DIFF
--- a/src/__tests__/serialize-test.ts
+++ b/src/__tests__/serialize-test.ts
@@ -223,8 +223,8 @@ describe('serialize', () => {
 
   describe('encodeObject', () => {
     it('produces the correct value', () => {
-      const input = { test: 'bar', foo: '94' };
-      const expectedOutput = 'test-bar_foo-94';
+      const input = { test: 'bar', foo: '94', bar: '' };
+      const expectedOutput = 'test-bar_foo-94_bar-';
       expect(encodeObject(input, '-', '_')).toBe(expectedOutput);
       expect(encodeObject(undefined)).not.toBeDefined();
       expect(encodeObject({})).not.toBeDefined();
@@ -233,11 +233,12 @@ describe('serialize', () => {
 
   describe('decodeObject', () => {
     it('produces the correct value', () => {
-      const output = decodeObject('foo-bar_jim-grill_iros-91');
+      const output = decodeObject('foo-bar_jim-grill_iros-91_baz-');
       const expectedOutput = {
         foo: 'bar',
         jim: 'grill',
         iros: '91',
+        baz: '',
       };
       expect(output).toEqual(expectedOutput);
       expect(decodeObject(undefined)).not.toBeDefined();

--- a/src/__tests__/serialize-test.ts
+++ b/src/__tests__/serialize-test.ts
@@ -223,8 +223,8 @@ describe('serialize', () => {
 
   describe('encodeObject', () => {
     it('produces the correct value', () => {
-      const input = { test: 'bar', foo: '94', bar: '' };
-      const expectedOutput = 'test-bar_foo-94_bar-';
+      const input = { test: 'bar', foo: '94', bar: '' , baz: '-baz-'};
+      const expectedOutput = 'test-bar_foo-94_bar-_baz--baz-';
       expect(encodeObject(input, '-', '_')).toBe(expectedOutput);
       expect(encodeObject(undefined)).not.toBeDefined();
       expect(encodeObject({})).not.toBeDefined();
@@ -233,12 +233,13 @@ describe('serialize', () => {
 
   describe('decodeObject', () => {
     it('produces the correct value', () => {
-      const output = decodeObject('foo-bar_jim-grill_iros-91_baz-');
+      const output = decodeObject('foo-bar_jim-grill_iros-91_baz-_t--x-');
       const expectedOutput = {
         foo: 'bar',
         jim: 'grill',
         iros: '91',
         baz: '',
+        t: '-x-'
       };
       expect(output).toEqual(expectedOutput);
       expect(decodeObject(undefined)).not.toBeDefined();

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -490,7 +490,7 @@ export function decodeObject(
   input: string | string[] | null | undefined,
   keyValSeparator = '-',
   entrySeparator = '_'
-): { [key: string]: string | undefined } | undefined {
+): { [key: string]: string } | undefined {
   if (input == null) {
     return undefined;
   }
@@ -501,12 +501,12 @@ export function decodeObject(
     return undefined;
   }
 
-  const obj: { [key: string]: string | undefined } = {};
+  const obj: { [key: string]: string } = {};
 
-  const keyValSeparatorRegExp = new RegExp(`${keyValSeparator}(.+)`);
+  const keyValSeparatorRegExp = new RegExp(`${keyValSeparator}(.*)`);
   objStr.split(entrySeparator).forEach(entryStr => {
     const [key, value] = entryStr.split(keyValSeparatorRegExp);
-    obj[key] = value === '' ? undefined : value;
+    obj[key] = value;
   });
 
   return obj;


### PR DESCRIPTION
I find it useful to be able to handle empty strings in objects. I'm not aware of any reason to not support it.