### PR TITLE
Add a dev check to ensure query-string is installed correctly #32

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,3 +56,24 @@ export {
 } from './updateLocation';
 export { encodeQueryParams } from './encodeQueryParams';
 export { decodeQueryParams } from './decodeQueryParams';
+
+if (process.env.NODE_ENV !== 'production') {
+  /*
+   * run checks to ensure a valid version of query-string is installed
+   * see https://github.com/pbeshai/use-query-params/issues/127 for discussion
+   */
+  const queryStringVersion = require('query-string/package.json').version;
+  // simple check of versions since we don't anticipate any new minor v5s and
+  // don't want to require the semver package as a dependency for just a simple
+  // dev check.
+  const validQueryStringInstalled =
+    /^5.1.[1-9][0-9]*/.test(queryStringVersion) ||
+    /^6\./.test(queryStringVersion);
+  if (!validQueryStringInstalled) {
+    throw new Error(
+      `serialize-query-params requires query-string ^5.1.1 || ^6, ` +
+        `but ${queryStringVersion} is installed. Note: you may also ` +
+        `see this message if you're using use-query-params.`
+    );
+  }
+}


### PR DESCRIPTION
After some discussion in https://github.com/pbeshai/use-query-params/issues/127, I've decided to try and make the package more dev friendly by putting in a warning if an incorrect query-string version is installed.